### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: python
 Priority: optional
 Maintainer: Stefan van der Walt <stefanv@berkeley.edu>
 Uploaders: Yaroslav Halchenko <debian@onerussian.com>
-Build-Depends: debhelper (>= 12),
+Build-Depends: debhelper,
                dh-python,
                python3-all,
                python3-setuptools,


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/python-simplenote/ec329c3d-fa2a-42c1-b794-f8f37a14dc85.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    lrwxrwxrwx  root/root   /usr/share/doc/python3-simplenote/html/_static/language_data.js -> ../../../../javascript/sphinxdoc/1.0/language_data.js
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/share/doc/python3-simplenote/html/_static/language_data.js
### Control files: lines which differ (wdiff format)
* Depends: python3:any, libjs-sphinxdoc (>= [-1.0)-] {+2.4.3-5~)+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/ec329c3d-fa2a-42c1-b794-f8f37a14dc85/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/ec329c3d-fa2a-42c1-b794-f8f37a14dc85/diffoscope)).
